### PR TITLE
typo fix for upgradestation BP

### DIFF
--- a/objects/power/fu_blastfurnace/fu_blastfurnace.object
+++ b/objects/power/fu_blastfurnace/fu_blastfurnace.object
@@ -9,7 +9,7 @@
   "price" : 900,
   "objectType" : "container",
   "printable" : false,
-  "learnBlueprintsOnPickup" : [ "isn_arcsmelter"," fu_upgrade" ],
+  "learnBlueprintsOnPickup" : [ "isn_arcsmelter","fu_upgrade" ],
   "scripts" : [ "/objects/power/fu_blastfurnace/fu_blastfurnace.lua",
                 "/objects/power/isn_sharedpowerscripts.lua",
 		"/objects/isn_sharedobjectscripts.lua"],


### PR DESCRIPTION
Picking up blast furnace currently gives PGI "recipe", due to leading space in bf.object; fixed here.