### PR TITLE
added ss sounds, fixed blink attk particles

### DIFF
--- a/monsters/skills/ranged/starspawnblinkattack.lua
+++ b/monsters/skills/ranged/starspawnblinkattack.lua
@@ -1,0 +1,93 @@
+starspawnBlinkAttack = {
+  initialDelay = 1,
+  postBlinkDelay = 0.2,
+  chargeDuration = 0.25,
+}
+
+function starspawnBlinkAttack.enter()
+  if not canStartSkill("starspawnBlinkAttack") then return nil end
+
+  local destination = starspawnBlinkAttack.findDestination(world.entityPosition(self.target))
+  if destination == nil then return nil end
+
+  return {
+    originalDestination = destination,
+    run = coroutine.wrap(starspawnBlinkAttack.run)
+  }
+end
+
+function starspawnBlinkAttack.enteringState(stateData)
+  entity.setAnimationState("movement", "idle")
+  entity.setAnimationState("attack", "idle")
+
+  entity.setActiveSkillName("starspawnBlinkAttack")
+end
+
+function starspawnBlinkAttack.update(dt, stateData)
+  if not canContinueSkill() then return true end
+
+  return stateData.run(stateData)
+end
+
+function starspawnBlinkAttack.leavingState(stateData)
+end
+
+function starspawnBlinkAttack.run(stateData)
+  starspawnBlinkAttack.wait(starspawnBlinkAttack.initialDelay, function()
+    if self.toTarget ~= nil then
+      mcontroller.controlFace(self.toTarget[1])
+    end
+  end)
+
+  -- Might have a better destination at this point
+  local destination = starspawnBlinkAttack.findDestination(world.entityPosition(self.target))
+  if destination == nil then
+    destination = stateData.originalDestination
+  end
+
+  if self.toTarget ~= nil then
+    mcontroller.controlFace(self.toTarget[1])
+  end
+
+  entity.burstParticleEmitter("blinkout")
+  entity.playSound("blinkSound")
+  mcontroller.setVelocity({ 0, 0 })
+  mcontroller.setPosition(destination)
+  coroutine.yield(false)
+
+  starspawnBlinkAttack.wait(starspawnBlinkAttack.postBlinkDelay, function()
+    if self.toTarget ~= nil then
+      mcontroller.controlFace(self.toTarget[1])
+    end
+  end)
+
+  return true
+end
+
+function starspawnBlinkAttack.wait(duration, action)
+  local timer = 0
+  while timer < duration do
+    if action ~= nil then action() end
+
+    timer = timer + script.updateDt()
+    coroutine.yield(false)
+  end
+end
+
+function starspawnBlinkAttack.findDestination(targetPosition)
+  if targetPosition == nil then return nil end
+
+  local collisionPoly = mcontroller.collisionPoly()
+  local direction = util.toDirection(self.toTarget[1])
+  local offsetXRange = entity.configParameter("starspawnBlinkAttack.offsetXRange")
+
+  for offsetX = offsetXRange[2], offsetXRange[1], -1 do
+    local destinationPosition = {targetPosition[1] + direction * offsetX, targetPosition[2]}
+    local resolvedPosition = world.resolvePolyCollision(collisionPoly, destinationPosition, 0.5)
+    if resolvedPosition then
+      return resolvedPosition
+    end
+  end
+
+  return nil
+end

--- a/monsters/skills/ranged/starspawnblinkattack.monsterskill
+++ b/monsters/skills/ranged/starspawnblinkattack.monsterskill
@@ -1,0 +1,19 @@
+{
+  "name" : "starspawnBlinkAttack",
+  "label" : "BLINK",
+  "image" : "/monsters/ground/skills/icon.png",
+
+  "parameters" : {
+    "scripts" : [ "/monsters/skills/ranged/starspawnBlinkAttack.lua" ],
+
+    "starspawnBlinkAttack" : {
+      "skillTimeLimit" : 1.5,
+      "cooldownTime" : 3,
+
+      "approachPoints" : [ [-13, 0], [13, 0] ],
+      "startRects" : [ [-18, 5, -10, -2.0], [18, 5, 10, -2.0] ],
+
+      "offsetXRange" : [1, 4]
+    }
+  }
+}

--- a/monsters/starspawn/starspawn.animation
+++ b/monsters/starspawn/starspawn.animation
@@ -395,7 +395,26 @@
       "particles" : [
       ]
     },
-
+    "blinkout" : {
+      "particles" : [
+        {
+          "particle" : {
+            "type" : "animated",
+            "animation" : "/animations/blinkout/blinkout.animation",
+            "size" : 1,
+            "angularVelocity" : 35,
+            "fade" : 1,
+            "destructionTime" : 5,
+            "position" : [0, 0],
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, 0],
+            "approach" : [1, 1],
+            "timeToLive" : 0.75,
+            "layer" : "front"
+          }
+        }
+      ]
+    },
     "deathPoof" : {
       "particles" : [
         {
@@ -587,7 +606,8 @@
   },
 
   "sounds" : {
-    "turnHostile" : [ ],
-    "deathPuff" : [ "/sfx/npc/enemydeathpuff.wav" ]
+    "turnHostile" : [ "/sfx/npc/smallbiped/teethyhead_small_idle2.wav"],
+    "deathPuff" : [ "/sfx/npc/smallbiped/powlhead_small_death.wav" ],
+    "blinkSound" : ["/sfx/gun/lightningcoil3.wav"]
   }
 }

--- a/monsters/starspawn/starspawn.monstertype
+++ b/monsters/starspawn/starspawn.monstertype
@@ -23,7 +23,7 @@
       "/monsters/ground/skills/createGroundRangedAttack.lua"
     ],
 
-    "baseSkills" : [ "starspawnSpitAttack", "blinkAttack" ],
+    "baseSkills" : [ "starspawnSpitAttack", "starspawnBlinkAttack" ],
     "specialSkills" : [ "starspawnShockAttack", "starspawnSwarmAttack", "starspawnPortalAttack" ],
 
     "projectileSourcePosition" : [0.75, -0.62],


### PR DESCRIPTION
While working out monster compatibility for nightly, I found an issue with the particle animation missing for the starspawn blink attack (this causes him to despawn in nightly). This fixes that. 

While I was at it I tacked on a couple more sounds for the starspawn. I like the changes you made to it by the way!