### PR TITLE
Make aquapod and vorit seeds require full immersion in water rather than preventing this. (Seems odd for aquatic plants.)

### DIFF
--- a/objects/farmables/aquapod/aquapodseed.object
+++ b/objects/farmables/aquapod/aquapodseed.object
@@ -40,6 +40,6 @@
     }
   ],
   "learnBlueprintsOnPickup" : [ "voritseed", "littlegoodberryseed" ],
-    "maxImmersion" : 1.0,
+    "minImmersion" : 1.0,
     "consumeSoilMoisture" : false
 }

--- a/objects/farmables/aquapod/wildaquapodseed.object
+++ b/objects/farmables/aquapod/wildaquapodseed.object
@@ -37,7 +37,7 @@
       "resetToStage" : 2
     }
   ],
-    "maxImmersion" : 1.0,
+    "minImmersion" : 1.0,
     "consumeSoilMoisture" : false,
   "breakDropOptions" : [
     [ [ "aquapodseed", 1, { } ] ]

--- a/objects/farmables/voritseed/voritseed.object
+++ b/objects/farmables/voritseed/voritseed.object
@@ -38,6 +38,6 @@
       "resetToStage" : 2
     }
   ],
-    "maxImmersion" : 1.0,
+    "minImmersion" : 1.0,
     "consumeSoilMoisture" : false
 }

--- a/recipes/armor/fujunkerhead.recipe
+++ b/recipes/armor/fujunkerhead.recipe
@@ -3,7 +3,7 @@
     { "item" : "densiniumbar", "count" : 3 },
     { "item" : "corefragmentore", "count" : 4 },
     { "item" : "refinedrubium", "count" : 3 },
-    { "item" : "solari", "count" : 2 }
+    { "item" : "solaricrystal", "count" : 2 }
   ],
   "output" : {
     "item" : "fujunkerhead",

--- a/recipes/armor/fujunkerlegs.recipe
+++ b/recipes/armor/fujunkerlegs.recipe
@@ -3,7 +3,7 @@
     { "item" : "densiniumbar", "count" : 4 },
     { "item" : "corefragmentore", "count" : 3 },
     { "item" : "refinedrubium", "count" : 4 },
-    { "item" : "solari", "count" : 2 }
+    { "item" : "solaricrystal", "count" : 2 }
   ],
   "output" : {
     "item" : "fujunkerpants",


### PR DESCRIPTION
I noticed that my aquapod and vorit seeds were getting "flooded out" in the cultivation tank that I'd built for them, and they're meant to be aquatic flora.  I've set full submersion as a requirement, although that *might* be too strict; a value of 0.9 would accommodate players who've set up plantations rather than using hydroponics.