### PR TITLE
Glowgel updates

### DIFF
--- a/objects/gels/isn_glowgel/isn_glowgel_b.recipe
+++ b/objects/gels/isn_glowgel/isn_glowgel_b.recipe
@@ -5,7 +5,7 @@
   ],
   "output" : {
     "item" : "isn_glowgel_b",
-    "count" : 1
+    "count" : 10
   },
   "groups" : [ "nanofabricator", "gear", "all"  ]
 }

--- a/objects/gels/isn_glowgel/isn_glowgel_g.recipe
+++ b/objects/gels/isn_glowgel/isn_glowgel_g.recipe
@@ -6,7 +6,7 @@
   ],
   "output" : {
     "item" : "isn_glowgel_g",
-    "count" : 1
+    "count" : 10
   },
   "groups" : [ "nanofabricator", "gear", "all"  ]
 }

--- a/objects/gels/isn_glowgel/isn_glowgel_mod.matmod
+++ b/objects/gels/isn_glowgel/isn_glowgel_mod.matmod
@@ -11,6 +11,6 @@
     "variants" : 5,
     "multiColored" : false,
     "zLevel" : 0,
-    "radiantLight" : [0.3, 0.3, 0.3]
+    "radiantLight" : [120, 120, 120]
   }
 }

--- a/objects/gels/isn_glowgel/isn_glowgel_mod_b.matmod
+++ b/objects/gels/isn_glowgel/isn_glowgel_mod_b.matmod
@@ -11,6 +11,6 @@
     "variants" : 5,
     "multiColored" : false,
     "zLevel" : 0,
-    "radiantLight" : [0, 0.15, 0.3]
+    "radiantLight" : [0, 60, 120]
   }
 }

--- a/objects/gels/isn_glowgel/isn_glowgel_mod_g.matmod
+++ b/objects/gels/isn_glowgel/isn_glowgel_mod_g.matmod
@@ -11,6 +11,6 @@
     "variants" : 5,
     "multiColored" : false,
     "zLevel" : 0,
-    "radiantLight" : [0, 0.3, 0]
+    "radiantLight" : [0, 120, 0]
   }
 }

--- a/objects/gels/isn_glowgel/isn_glowgel_mod_p.matmod
+++ b/objects/gels/isn_glowgel/isn_glowgel_mod_p.matmod
@@ -11,6 +11,6 @@
     "variants" : 5,
     "multiColored" : false,
     "zLevel" : 0,
-    "radiantLight" : [0.15, 0, 0.3]
+    "radiantLight" : [60, 0, 120]
   }
 }

--- a/objects/gels/isn_glowgel/isn_glowgel_mod_r.matmod
+++ b/objects/gels/isn_glowgel/isn_glowgel_mod_r.matmod
@@ -11,6 +11,6 @@
     "variants" : 5,
     "multiColored" : false,
     "zLevel" : 0,
-    "radiantLight" : [0.3, 0, 0]
+    "radiantLight" : [120, 0, 0]
   }
 }

--- a/objects/gels/isn_glowgel/isn_glowgel_mod_y.matmod
+++ b/objects/gels/isn_glowgel/isn_glowgel_mod_y.matmod
@@ -11,6 +11,6 @@
     "variants" : 5,
     "multiColored" : false,
     "zLevel" : 0,
-    "radiantLight" : [0.3, 0.3, 0]
+    "radiantLight" : [120, 120, 0]
   }
 }

--- a/objects/gels/isn_glowgel/isn_glowgel_p.recipe
+++ b/objects/gels/isn_glowgel/isn_glowgel_p.recipe
@@ -6,7 +6,7 @@
   ],
   "output" : {
     "item" : "isn_glowgel_p",
-    "count" : 1
+    "count" : 10
   },
   "groups" : [ "nanofabricator", "gear", "all"  ]
 }

--- a/objects/gels/isn_glowgel/isn_glowgel_y.recipe
+++ b/objects/gels/isn_glowgel/isn_glowgel_y.recipe
@@ -5,7 +5,7 @@
   ],
   "output" : {
     "item" : "isn_glowgel_y",
-    "count" : 1
+    "count" : 10
   },
   "groups" : [ "nanofabricator", "gear", "all"  ]
 }


### PR DESCRIPTION
Change glowgel light levels. Also standardized recipe output for colored variants.

(Sorry about the extra stuff. I think the automatically generated merge commits won't change anything, and the .gitignore file should be exactly the same as what exists. I'll check the diffs after I submit this to be sure.)