### PR TITLE
Power Press and biolumi gene quest fixes

### DIFF
--- a/npcs/scienceoutpost/fuoutpostnovakidscientist.npctype
+++ b/npcs/scienceoutpost/fuoutpostnovakidscientist.npctype
@@ -3,7 +3,7 @@
   "baseType" : "fuoutpostcivilian",
   "damageTeam" : 1,
     "scriptConfig" : {
-        "offeredQuests" : [ "powerpress.gearup", "1copperplate.gearup" ],
+        "offeredQuests" : [ "1copperplate.gearup" ],
         "turnInQuests" : [ "1copperplate.gearup" ],
         
     "wander" : {

--- a/quests/FU_main/powerpress.questtemplate
+++ b/quests/FU_main/powerpress.questtemplate
@@ -3,7 +3,7 @@
   "prerequisites" : [ "fu_intro2.gearup" ],
   "title" : "^#1693d5;The Power Press",
   "text" : "Sometimes, basic metals just aren't enough. A ^orange;Power Press^white; is designed specifically to press metals into new alloys and plates for crafting. ^green;Build one in your Matter Assembler^white;!",
-  "completionText" : "Many other materials can be created in this fashion. Let's move on to mineral samples. Oh, and take this. It isn't much now, but once you upgrade it a bit...",
+  "completionText" : "'This just in: ^orange;New ores discovered!^white; Power Press no longer necessary.' Lovely. Well, you don't need to make that Power Press anymore. Technology marches on...",
   "speaker" : "questGiver",
   "moneyRange" : [0, 0],
   "rewards" : [],
@@ -12,9 +12,10 @@
   "script" : "/quests/scripts/main.lua",
   "scriptConfig" : {
     "gatherRequirements" : {
+	  "requireTurnIn" : false,
       "items" : {
         "powerpress" : {
-          "count" : 1,
+          "count" : 0,
           "consume" : false
         }
       }

--- a/quests/xenolab/4bioluminescent.questtemplate
+++ b/quests/xenolab/4bioluminescent.questtemplate
@@ -2,7 +2,7 @@
   "id" : "4bioluminescent.gearup",
   "prerequisites" : [  ],
   "title" : "^#1693d5;Luminescent gene",
-  "text" : "Excitement. Now you have to find a very interesting gene. ^orange;Bioluminescent gene^white; can be found within Glow Fibres. You'll need 6 or more.",
+  "text" : "Excitement. Now you have to find a very interesting gene. ^orange;Bioluminescent gene^white; can be found within Glow Fibres. You'll need 25 or more.",
   "completionText" : "Statement. These genes can be used to craft ^orange;glowing plants^white; in the Design Lab.",
   "speaker" : "questGiver",
   "moneyRange" : [0, 0],


### PR DESCRIPTION
Fixes for power press quest from science outpost (to facilitate removal) and fixes to quest text for bioluminescent gene extraction.