### PR TITLE
Rarity re-sorting for Matter Assemb stations

### DIFF
--- a/objects/beestation/beestation.object
+++ b/objects/beestation/beestation.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "beestation",
   "colonyTags" : [ "bees", "insects" ],
-  "rarity" : "rare",
+  "rarity" : "Common",
   "interactAction" : "OpenCraftingInterface",
   "interactData" : {
     "config" : "/interface/windowconfig/beestation.config",  

--- a/objects/power/centrifuge/centrifuge.object
+++ b/objects/power/centrifuge/centrifuge.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "centrifuge",
-  "rarity" : "rare",
+  "rarity" : "uncommon",
   "colonyTags" : [ "science" ],
   "description" : "A useful device for separating immiscible liquids. Needs 2u power.",
   "shortdescription" : "Lab Centrifuge",

--- a/objects/power/fu_quantumgenerator/fu_quantumgenerator.object
+++ b/objects/power/fu_quantumgenerator/fu_quantumgenerator.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "fu_quantumgenerator",
-  "rarity" : "Common",
+  "rarity" : "legendary",
     "colonyTags" : [ "science" ],
   "category" : "wire",
   "objectType" : "container",

--- a/objects/power/isn_atmosregulator/isn_atmosregulator.object
+++ b/objects/power/isn_atmosregulator/isn_atmosregulator.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "isn_atmosregulator",
-  "rarity" : "Rare",
+  "rarity" : "legendary",
     "colonyTags" : [ "science" ],
   "description" : "Generates a field that protects against environmental hazards. Requires 24u of power.",
   "shortdescription" : "Atmospheric Regulator",

--- a/objects/power/isn_battery_t3_fero/isn_battery_t3_fero.object
+++ b/objects/power/isn_battery_t3_fero/isn_battery_t3_fero.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "isn_battery_t3_fero",
-  "rarity" : "Uncommon",
+  "rarity" : "legendary",
     "colonyTags" : [ "science" ],
   "category" : "wire",
   "price" : 2500,

--- a/objects/power/quantumextractor/quantumextractor.object
+++ b/objects/power/quantumextractor/quantumextractor.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "quantumextractor",
   "colonyTags" : [ "fu", "science", "scienceoutpost", "radiation" ],
-  "rarity" : "Common",
+  "rarity" : "legendary",
   "race" : "generic",
   "category" : "crafting",
   "printable" : false,


### PR DESCRIPTION
Rarity class changes for craftable stations. This might be a better hint for users on what follows what, especially where to start (the white/common stuff!)