### PR TITLE
Another quadruped fix

### DIFF
--- a/dungeons/DungeoneerDungeons/microdungeons/randomencounter/glitch/glitchencounter.dungeon
+++ b/dungeons/DungeoneerDungeons/microdungeons/randomencounter/glitch/glitchencounter.dungeon
@@ -6786,7 +6786,7 @@
           "npc",
           {
             "kind": "monster",
-            "typeName": "quadruped",
+            "typeName": "poptop",
             "seed": "stable",
             "parameters": {
               "aggressive": false


### PR DESCRIPTION
Replace another "quadruped" reference with "poptop". Was causing crash-to-ship